### PR TITLE
✨ Remove prefix default in commit message (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,35 +40,6 @@ This repository includes a bash script to automate the process of adding, commit
 ## Running the Bash Script
 The bash script `git-add-commit-push-all-in-one.sh` simplifies the process of adding, committing, and pushing changes to your Git repository.
 
-### Linux and macOS
-1. Open your terminal.
-
-2. Navigate to the directory where the script is located:
-
-    ```bash
-    cd path/to/devtools
-    ```
-
-3. Ensure the script has execution permissions:
-
-    ```bash
-    chmod +x git-add-commit-push-all-in-one.sh
-    ```
-
-4. Run the script:
-
-    ```bash
-    ./git-add-commit-push-all-in-one.sh
-    ```
-
-    To run the script without emojis in commit messages:
-
-    ```bash
-    ./git-add-commit-push-all-in-one.sh --no-emoji
-    ```
-
-### Windows
-
 1. Open Git Bash.
 
 2. Navigate to the directory where the script is located:
@@ -100,20 +71,20 @@ The bash script `git-add-commit-push-all-in-one.sh` simplifies the process of ad
 To use the script, run it with the desired `commit type` and `message`, it will automatically add, commit, and push to the remote branch. Here are some examples:
 
 ```bash
-# When you type this command, it equivalent to: git add -A && git commit -m "✨ feat: implement new feature" && git push
+# When you type this command, it equivalent to: git add -A && git commit -m "✨ implement new feature" && git push
 git feat "implement new feature"
 ```
 Similar example:
 ```bash
-git fix "fix bug"                       # git commit -m "🐛 fix: fix bug"
-git docs "update documentation"         # git commit -m "📚 docs: update documentation"
-git style "format code"                 # git commit -m "💄 style: format code"
-git refactor "refactor code"            # git commit -m "♻️ refactor: refactor code"
-git perf "improve performance"          # git commit -m "⚡ perf: improve performance"
-git test "add tests"                    # git commit -m "✅ tests: add tests"
-git chore "update dependencies"         # git commit -m "🔧 chore: update dependencies"
-git build "run build"                   # git commit -m "🛠️ build: run build"
-git ci "update CI configuration"        # git commit -m "👷 ci: update CI configuration"
+git fix "fix bug"                       # git commit -m "🐛 fix bug"
+git docs "update documentation"         # git commit -m "📚 update documentation"
+git style "format code"                 # git commit -m "💄 format code"
+git refactor "refactor code"            # git commit -m "♻️ refactor code"
+git perf "improve performance"          # git commit -m "⚡ improve performance"
+git test "add tests"                    # git commit -m "✅ add tests"
+git chore "update dependencies"         # git commit -m "🔧 update dependencies"
+git build "run build"                   # git commit -m "🛠️ run build"
+git ci "update CI configuration"        # git commit -m "👷 update CI configuration"
 ```
 
 ## Contributing

--- a/git-add-commit-push-all-in-one.sh
+++ b/git-add-commit-push-all-in-one.sh
@@ -13,7 +13,7 @@ set_git_alias() {
   
   git config --global alias.$alias_name "!f() { 
     git add -A && 
-    git commit -m \"$commit_prefix: \$1\" && 
+    git commit -m \"$commit_prefix \$1\" && 
     branch=\$(git symbolic-ref --short HEAD) && 
     upstream=\$(git for-each-ref --format='%(upstream:short)' refs/heads/\$branch) && 
     if [ -z \"\$upstream\" ]; then 
@@ -36,15 +36,15 @@ do
 done
 
 # Setting up aliases
-set_git_alias "feat" "✨ feat" $USE_EMOJI
-set_git_alias "fix" "🐛 fix" $USE_EMOJI
-set_git_alias "docs" "📚 docs" $USE_EMOJI
-set_git_alias "style" "💄 style" $USE_EMOJI
-set_git_alias "refactor" "♻️ refactor" $USE_EMOJI
-set_git_alias "perf" "⚡ perf" $USE_EMOJI
-set_git_alias "test" "✅ test" $USE_EMOJI
-set_git_alias "chore" "🔧 chore" $USE_EMOJI
-set_git_alias "build" "🛠️ build" $USE_EMOJI
-set_git_alias "ci" "👷 ci" $USE_EMOJI
+set_git_alias "feat" "✨" $USE_EMOJI
+set_git_alias "fix" "🐛" $USE_EMOJI
+set_git_alias "docs" "📚" $USE_EMOJI
+set_git_alias "style" "💄" $USE_EMOJI
+set_git_alias "refactor" "♻️" $USE_EMOJI
+set_git_alias "perf" "⚡" $USE_EMOJI
+set_git_alias "test" "✅" $USE_EMOJI
+set_git_alias "chore" "🔧" $USE_EMOJI
+set_git_alias "build" "🛠️" $USE_EMOJI
+set_git_alias "ci" "👷" $USE_EMOJI
 
 echo "Git aliases have been set up successfully."


### PR DESCRIPTION
Remove the prefix commit message such "feat: ".
Everyone feels free to say something, unconstrained by anything.